### PR TITLE
Fix global-escaping i variable

### DIFF
--- a/javascript/payeezy_us_v5.1.js
+++ b/javascript/payeezy_us_v5.1.js
@@ -16,7 +16,7 @@ var Payeezy = function() {
     }
 
     function t() {
-        var e = [];
+        var i, e = [];
         var t = document.getElementsByTagName("input");
         var n = document.getElementsByTagName("select");
         for (i = 0; i < t.length; i++) {


### PR DESCRIPTION
Failure to declare `i` used in for loops as a function-level var leaks that name into the global namespace.